### PR TITLE
Added mandatory "device" path to volumes example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,19 @@ volumes:
     driver_opts:
       o: bind
       type: none
+      device: /srv/docker/grakndata
   esdata:
     driver: local
     driver_opts:
       o: bind
       type: none
+      device: /srv/docker/esdata
   s3data:
     driver: local
     driver_opts:
       o: bind
-      type: none      
+      type: none
+      device: /srv/docker/s3data
 ```
 
 ## Memory configuration


### PR DESCRIPTION
By using the example provided, the following error will show up:
Creating volume "architecture_grakndata" with local driver
ERROR: create architecture_grakndata: missing required option: "device"

To resolve this issue, it simply needs to add the mandatory "device" option.