### PR TITLE
Update from Elasticsearch 7.5.0 to 7.5.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     image: redis:5.0.5
     restart: always
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.5.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.5.2
     volumes:
       - esdata:/usr/share/elasticsearch/data
     environment:


### PR DESCRIPTION
Updated Elasticsearch to the current version, 7.5.2.