### PR TITLE
Bump dependencies

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -8,13 +8,13 @@ services:
       - 48555:48555
   opencti-dev-redis:
     container_name: opencti-dev-redis
-    image: redis:5.0.5
+    image: redis:5.0.8
     restart: always
     ports:
       - 6379:6379
   opencti-dev-elasticsearch:
     container_name: opencti-dev-elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.5.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.6.1
     environment:
       - discovery.type=single-node
     restart: always
@@ -30,7 +30,7 @@ services:
       - 9300:9300
   opencti-dev-minio:
     container_name: opencti-dev-minio
-    image: minio/minio:RELEASE.2019-10-12T01-39-57Z
+    image: minio/minio:RELEASE.2020-03-19T21-49-00Z
     ports:
       - "9000:9000"
     environment:
@@ -44,7 +44,7 @@ services:
       retries: 3      
   opencti-dev-rabbitmq:
     container_name: opencti-dev-rabbitmq
-    image: rabbitmq:3.7.17-management
+    image: rabbitmq:3.7-management
     restart: always
     ports:
       - 5672:5672

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -14,7 +14,7 @@ services:
       - 6379:6379
   opencti-dev-elasticsearch:
     container_name: opencti-dev-elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.6.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.6.2
     environment:
       - discovery.type=single-node
     restart: always

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -14,7 +14,7 @@ services:
       - 6379:6379
   opencti-dev-elasticsearch:
     container_name: opencti-dev-elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.6.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.6.1
     environment:
       - discovery.type=single-node
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     image: redis:5.0.8
     restart: always
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.6.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.6.2
     volumes:
       - esdata:/usr/share/elasticsearch/data
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     image: redis:5.0.8
     restart: always
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.6.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.6.1
     volumes:
       - esdata:/usr/share/elasticsearch/data
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,10 @@ services:
       - grakndata:/grakn-core-all-linux/server/db
     restart: always
   redis:
-    image: redis:5.0.5
+    image: redis:5.0.8
     restart: always
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.5.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.6.1
     volumes:
       - esdata:/usr/share/elasticsearch/data
     environment:
@@ -25,7 +25,7 @@ services:
         soft: 65536
         hard: 65536
   minio:
-    image: minio/minio:RELEASE.2019-10-12T01-39-57Z
+    image: minio/minio:RELEASE.2020-02-27T00-23-05Z
     volumes:
       - s3data:/data
     ports:
@@ -40,7 +40,7 @@ services:
       timeout: 20s
       retries: 3
   rabbitmq:
-    image: rabbitmq:3.7.17-management
+    image: rabbitmq:3.7-management
     environment:
       - RABBITMQ_DEFAULT_USER=${RABBITMQ_DEFAULT_USER}
       - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}    


### PR DESCRIPTION
From my testing those dependencies can be safely updated.
Even Elasticsearch seems to work fine after the minor version update without throwing any errors.