### PR TITLE
[Docker-dev file] Updated Graken Image value

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   opencti-dev-grakn:
     container_name: opencti-dev-grakn 
-    image: graknlabs/grakn:1.7.2
+    image: graknlabs/grakn:1.8.1
     restart: always
     ports:
       - 48555:48555


### PR DESCRIPTION
[Docker-dev file] To increase the graken base image to 1.8.1 to match the graken-client version within package.json file in frontend (#no issue number that I know of)