### PR TITLE
Disable X-Pack ML due to startup errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - esdata:/usr/share/elasticsearch/data
     environment:
       - discovery.type=single-node
+      - xpack.ml.enabled=false
     restart: always
     ulimits:
       memlock:


### PR DESCRIPTION
Per [this Slack discussion](https://luatix.slack.com/archives/CHZC2D38C/p1621572947059800), it turns out that ElasticSearch doesn't start with the latest master unless the ML X-Pack is disabled. Since these  X-Pack extensions do not appear to be used, they can be disabled.

Here's a snippet of the error:

```
elasticsearch_1  | uncaught exception in thread [main]
elasticsearch_1  | ElasticsearchException[Failure running machine learning native code. This could be due to running on an unsupported OS or distribution, missing OS libraries, or a problem with the temp directory. To bypass this problem by running Elasticsearch without machine learning functionality set [xpack.ml.enabled: false].]
```

I'm experiencing this with master both on recent macOS and Debian Linux that start out with a clean `docker-compose up`.