### PR TITLE
Fix minio ENV. Update restart policy to unless-stopped

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -3,7 +3,7 @@ services:
   opencti-dev-redis:
     container_name: opencti-dev-redis
     image: redis:6.2.5
-    restart: always
+    restart: unless-stopped
     ports:
       - 6379:6379
   opencti-dev-elasticsearch:
@@ -13,7 +13,7 @@ services:
       - discovery.type=single-node
       - "ES_JAVA_OPTS=-Xms4G -Xmx4G"
       - xpack.ml.enabled=false
-    restart: always
+    restart: unless-stopped
     ulimits:
       memlock:
         soft: -1
@@ -29,6 +29,7 @@ services:
     image: docker.elastic.co/kibana/kibana:7.14.1
     environment:
       - ELASTICSEARCH_HOSTS=http://opencti-dev-elasticsearch:9200
+    restart: unless-stopped
     ports:
       - 5601:5601
   opencti-dev-minio:
@@ -38,19 +39,19 @@ services:
       - "9000:9000"
       - "9001:9001"
     environment:
-      MINIO_ROOT_USER: ChangeMeAccess
-      MINIO_ROOT_PASSWORD: ChangeMeKey
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
     command: server /data --console-address ":9001"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 30s
       timeout: 20s
       retries: 3
-    restart: always
+    restart: unless-stopped
   opencti-dev-rabbitmq:
     container_name: opencti-dev-rabbitmq
     image: rabbitmq:3.9-management
-    restart: always
+    restart: unless-stopped
     ports:
       - 5672:5672
       - 15672:15672


### PR DESCRIPTION
- use  environment variable  for minio
- Update restart policy to `unless-stopped` as it's more convenient for local development use.  `unless-stopped` is similar to `always`, except that when the container is stopped (manually or otherwise), it is not restarted even after Docker daemon restarts. See https://docs.docker.com/config/containers/start-containers-automatically/
