### PR TITLE
Fixed in-line comments on Elastic clustering settings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,9 @@ services:
     volumes:
       - esdata:/usr/share/elasticsearch/data
     environment:
-      # Comment out the line below for single-node
+      # Comment-out the line below for a cluster of multiple nodes
       - discovery.type=single-node
-      # Uncomment line below below for a cluster of multiple nodes
+      # Uncomment the line below below for a cluster of multiple nodes
       # - cluster.name=docker-cluster
       - xpack.ml.enabled=false
       - xpack.security.enabled=false


### PR DESCRIPTION
The comments were incorrect. `discovery.type=single-node` must be commented-out in order for ES to default to a multi-node setup.

https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-settings.html#:~:text=Defaults%20to%20multi%2Dnode

> **discovery.type**
> ([Static](https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html#static-cluster-setting)) Specifies whether Elasticsearch should form a multiple-node cluster. Defaults to multi-node, which means that Elasticsearch discovers other nodes when forming a cluster and allows other nodes to join the cluster later. If set to single-node, Elasticsearch forms a single-node cluster and suppresses the timeout set by cluster.publish.timeout. For more information about when you might use this setting, see [Single-node discovery](https://www.elastic.co/guide/en/elasticsearch/reference/current/bootstrap-checks.html#single-node-discovery).