### PR TITLE
Add hostname for RabbitMQ container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
     environment:
       - RABBITMQ_DEFAULT_USER=${RABBITMQ_DEFAULT_USER}
       - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}
+    hostname: rabbitmq-opencti
     volumes:
       - amqpdata:/var/lib/rabbitmq
     restart: always


### PR DESCRIPTION
RabbitMQ derives directory names for volumes from the hostname of the container, which means that data can be lost between restarts/deployments as the hostname of the container (and thus the directory) changes. Hard-coding the hostname eliminates this problem.

This is a likely fix for a number of issues I've raised, including:
* https://github.com/OpenCTI-Platform/opencti/issues/3424
* https://github.com/OpenCTI-Platform/opencti/issues/3373 (the sub-issue mentioned [partway down the thread](https://github.com/OpenCTI-Platform/opencti/issues/3373#issuecomment-1573560643)
* https://github.com/OpenCTI-Platform/opencti/issues/3107

Since the OpenCTI [Docs](https://docs.opencti.io/5.7.X/deployment/installation/#:~:text=For%20production%20deployment%2C%20we%20recommend%20to%20deploy%20all%20components%20in%20containers%2C%20including%20dependencies%2C%20using%20native%20cloud%20services%20or%20orchestration%20systems%20such%20as%20Kubernetes.) now recommend Docker as the deployment method, it makes sense to eliminate this issue from the provided example compose configuration.

Prior to the suggested fix, Docker deployments can result in many sub-directories being created in RabbitMQ's `mnesia` directory with the container ID as the directory name as seen here:

![image](https://github.com/OpenCTI-Platform/docker/assets/107847353/db8b2624-eb74-464c-9409-ee1d60c67edb)

I do not know if data can be recovered from previously orphaned mnesia directories. Our own deployments have hundreds of MB of orphaned data. Perhaps the developers who know more about what is stored in the queues could investigate whether it's possible to write a script to extract the orphaned data and feed it back into the new permanent queue.

Further reading:
* [RabbitMQ node names](https://docs.vmware.com/en/VMware-RabbitMQ/1.4/vmware-rabbitmq-oci/clustering.html#node-names:~:text=RabbitMQ%20nodes%20are%20identified%20by%20node%20names.%20A%20node%20name%20consists%20of%20two%20parts%2C%20a%20prefix%20(usually%20rabbit)%20and%20hostname.%20For%20example%2C%20rabbit%40node1.messaging.svc.local%20is%20a%20node%20name%20with%20the%20prefix%20of%20rabbit%20and%20hostname%20of%20node1.messaging.svc.local.)
* A previous issue where an OpenCTI user discovered this same problem: https://github.com/OpenCTI-Platform/opencti/issues/1288#issuecomment-826263880