### PR TITLE
OpenSearch version of composes

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,12 +8,11 @@ services:
       - 6379:6379
   opencti-dev-elasticsearch:
     container_name: opencti-dev-elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.8.1
+    image: opensearchproject/opensearch:2.8.0
     environment:
       - discovery.type=single-node
-      - xpack.ml.enabled=false
-      - xpack.security.enabled=false
-      - "ES_JAVA_OPTS=-Xms8G -Xmx8G"
+      - plugins.security.disabled=true
+      - "OPENSEARCH_JAVA_OPTS=-Xms8G -Xmx8G"
     restart: unless-stopped
     ulimits:
       memlock:
@@ -27,9 +26,10 @@ services:
       - 9300:9300
   opencti-dev-kibana:
     container_name: opencti-dev-kibana
-    image: docker.elastic.co/kibana/kibana:8.8.1
+    image: opensearchproject/opensearch-dashboards:2.8.0
     environment:
-      - ELASTICSEARCH_HOSTS=http://opencti-dev-elasticsearch:9200
+      - OPENSEARCH_HOSTS=http://opencti-dev-elasticsearch:9200
+      - DISABLE_SECURITY_DASHBOARDS_PLUGIN=true
     restart: unless-stopped
     ports:
       - 5601:5601

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,17 +6,16 @@ services:
     volumes:
       - redisdata:/data
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.8.1
+    image: opensearchproject/opensearch:2.8.0
     volumes:
-      - esdata:/usr/share/elasticsearch/data
+      - esdata:/usr/share/opensearch/data
     environment:
       # Comment-out the line below for a cluster of multiple nodes
       - discovery.type=single-node
       # Uncomment the line below below for a cluster of multiple nodes
       # - cluster.name=docker-cluster
-      - xpack.ml.enabled=false
-      - xpack.security.enabled=false
-      - "ES_JAVA_OPTS=-Xms${ELASTIC_MEMORY_SIZE} -Xmx${ELASTIC_MEMORY_SIZE}"
+      - plugins.security.disabled=true
+      - "OPENSEARCH_JAVA_OPTS=-Xms${ELASTIC_MEMORY_SIZE} -Xmx${ELASTIC_MEMORY_SIZE}"
     restart: always
     ulimits:
       memlock:


### PR DESCRIPTION
I make some changes in `docker-compose.yml` and `docker-compose.dev.yml` to deploy OpenCTI with OpenSearch engine instead of Elastic.
It is also closes #75 