### PR TITLE
Update Minio image for CPU compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
         soft: 65536
         hard: 65536
   minio:
-    image: minio/minio:RELEASE.2024-01-16T16-07-38Z
+    image: minio/minio:RELEASE.2024-01-16T16-07-38Z # Use "minio/minio:RELEASE.2024-01-16T16-07-38Z-cpuv1" to troubleshoot compatibility issues with CPU
     volumes:
       - s3data:/data
     ports:


### PR DESCRIPTION
## Description

Upon attempting to start the OpenCTI platform after installation on Docker, the following errors were encountered:

**An error related to Minio:**

```
opencti_1 | {"category":"APP","errors":[{"attributes":{"genre":"TECHNICAL","http_status":500},"message":"getaddrinfo EAI_AGAIN minio","name":"UNKNOWN_ERROR","stack":"UNKNOWN_ERROR: getaddrinfo EAI_AGAIN minio\n    at error (/opt/opencti/build/src/config/errors.js:8:10)\n    at UnknownError (/opt/opencti/build/src/config/errors.js:76:47)\n    at Object._logWithError (/opt/opencti/build/src/config/conf.js:331:23)\n    at Object.error (/opt/opencti/build/src/config/conf.js:341:48)\n    at platformStart (/opt/opencti/build/src/boot.js:47:12)\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)"},{"message":"getaddrinfo EAI_AGAIN minio","name":"Error","stack":"Error: getaddrinfo EAI_AGAIN minio\n    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:118:26)"}],"level":"error","message":"Platform unmanaged direct error","timestamp":"2024-04-16T18:09:58.468Z","version":"6.0.9"}
```

```
minio_1 | Fatal glibc error: CPU does not support x86-64-v2
```

## Solution

To address the Minio-related error, I used the following Minio image:

```yaml
image: minio/minio:RELEASE.2024-01-16T16-07-38Z-cpuv1
```