### PR TITLE
[docker] Replace redis with valkey. Valkey remains BSD-licensed.

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,8 +1,8 @@
 version: '3'
 services:
-  opencti-dev-redis:
-    container_name: opencti-dev-redis
-    image: redis:7.2.5
+  opencti-dev-valkey:
+    container_name: opencti-dev-valkey
+    image: valkey/valkey:7.2.5
     restart: unless-stopped
     ports:
       - "6379:6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 version: '3'
 services:
-  redis:
-    image: redis:7.2.5
+  valkey:
+    image: valkey/valkey:7.2.6
     restart: always
     volumes:
-      - redisdata:/data
+      - vkdata:/data
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
     volumes:
@@ -57,7 +57,7 @@ services:
       - APP__ADMIN__PASSWORD=${OPENCTI_ADMIN_PASSWORD}
       - APP__ADMIN__TOKEN=${OPENCTI_ADMIN_TOKEN}
       - APP__APP_LOGS__LOGS_LEVEL=error
-      - REDIS__HOSTNAME=redis
+      - REDIS__HOSTNAME=valkey
       - REDIS__PORT=6379
       - ELASTICSEARCH__URL=http://elasticsearch:9200
       - MINIO__ENDPOINT=minio
@@ -77,7 +77,7 @@ services:
     ports:
       - "8080:8080"
     depends_on:
-      - redis
+      - valkey
       - elasticsearch
       - minio
       - rabbitmq
@@ -187,6 +187,6 @@ services:
 volumes:
   esdata:
   s3data:
-  redisdata:
+  vkdata:
   amqpdata:
 


### PR DESCRIPTION
Redis has switched to a more restrictive license after 7.2.4. Project forked, and valkey 7.2.5 is the first "production release" of valkey, which is basically the same code as Redis 7.2.4, but retaining the BSD license.