### PR TITLE
Add a 2 GB memory limit for Redis

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,6 +3,7 @@ services:
     container_name: opencti-dev-redis
     image: redis:7.4.0
     restart: unless-stopped
+    command: ["redis-server", "--appendonly", "no", "--maxmemory", "2gb", "--maxmemory-policy", "allkeys-lru"]
     ports:
       - "6379:6379"
   opencti-dev-elasticsearch:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   redis:
     image: redis:7.4.0
     restart: always
+    command: ["redis-server", "--appendonly", "no", "--maxmemory", "2gb", "--maxmemory-policy", "allkeys-lru"]
     volumes:
       - redisdata:/data
     healthcheck:


### PR DESCRIPTION
Without a memory limit Redis will consume all memory.