### PR TITLE
Fix rabbitmq.conf source location

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       - RABBITMQ_NODENAME=rabbit01@localhost
     volumes:
       - type: bind
-        source: rabbitmq.conf
+        source: ./rabbitmq.conf
         target: /etc/rabbitmq/rabbitmq.conf 
       - amqpdata:/var/lib/rabbitmq
     restart: always


### PR DESCRIPTION
docker-compose version 1.29.2 (Debian 12) seems to error out with  `ERROR: for rabbitmq  Cannot create container for service rabbitmq: invalid mount config for type "bind": invalid mount path: 'rabbitmq.conf' mount path must be absolute`

Changing the source location to a relative path seems to make the error go away, despite the mention of an absolute path.