### PR TITLE
Improve ElasticSearch healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,8 @@ services:
         hard: 65536
     healthcheck:
       test: ["CMD-SHELL", "curl -fs http://elasticsearch:9200/_cluster/health?wait_for_status=yellow || exit 1"]
-      interval: 30s
-      timeout: 10s
+      interval: 5s
+      timeout: 3s
       retries: 50
   minio:
     image: minio/minio:RELEASE.2024-05-28T17-19-04Z # Use "minio/minio:RELEASE.2024-05-28T17-19-04Z-cpuv1" to troubleshoot compatibility issues with CPU

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
         soft: 65536
         hard: 65536
     healthcheck:
-      test: ["CMD-SHELL", "curl -fs http://elasticsearch:9200/_cluster/health?wait_for_status=yellow || exit 1"]
+      test: ["CMD-SHELL", "curl -s http://elasticsearch:9200/_cluster/health?wait_for_status=yellow >/dev/null || exit 1"]
       interval: 5s
       timeout: 3s
       retries: 50

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
         soft: 65536
         hard: 65536
     healthcheck:
-      test: curl -s http://elasticsearch:9200 >/dev/null || exit 1
+      test: ["CMD-SHELL", "curl -fs http://elasticsearch:9200/_cluster/health?wait_for_status=yellow || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 50


### PR DESCRIPTION
The elasticsearch health check can pass before the cluster is actually up properly/healthly/available:
* https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-health
* https://www.baeldung.com/ops/elasticsearch-docker-compose#2-health-check-logic

This PR refines the health check to verify that the cluster is available (at least "yellow" status) before passing, and lowers the healthcheck interval to improve application start times.

I've maintained the existing convention of using `curl -s` and `>/dev/null` to suppress failures before the cluster is healthy. I'm proposing a 5s interval with 3s response time, as the existing 30s interval with 10s failure time can introduce up to ~39 seconds of unnecessary waiting into the application stack start time. 5s interval with 3s response time seems like a good middle-ground between fast start times and not spamming the elastic cluster with health check requests.