### PR TITLE
feat: bundle XTM One in the default stack

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -49,3 +49,30 @@ CONNECTOR_ANALYSIS_ID=4dffd77c-ec11-4abe-bca7-fd997f79fa36
 
 CONNECTOR_OPENCTI_ID=dd010812-9027-4726-bf7b-4936979955ae
 CONNECTOR_MITRE_ID=8307ea1e-9356-408c-a510-2d7f8b28a0e2
+
+###########################
+# XTM ONE                 #
+###########################
+
+# Shared secret used by OpenCTI and XTM One to authenticate registration.
+# Both platforms MUST use the same value.
+PLATFORM_REGISTRATION_TOKEN=xtm-default-registration-token
+
+XTM_ONE_HOST=localhost
+XTM_ONE_PORT=4000
+XTM_ONE_EXTERNAL_SCHEME=http
+# Image tag for filigran/xtm-one and filigran/xtm-one-worker (e.g. rolling, 1.x.y)
+XTM_ONE_VERSION=rolling
+XTM_ONE_ADMIN_EMAIL=admin@filigran.io
+XTM_ONE_ADMIN_PASSWORD=ChangeMe
+# Long random string (e.g. `openssl rand -hex 32`). Used to sign sessions/tokens.
+XTM_ONE_SECRET_KEY=ChangeMeWithGeneratedRandomString
+# Credentials for the dedicated pgsql-copilot Postgres instance.
+XTM_ONE_POSTGRES_USER=copilot
+XTM_ONE_POSTGRES_PASSWORD=ChangeMe
+# Optional: bucket name in MinIO (auto-created on first boot)
+XTM_ONE_S3_BUCKET=copilot-files
+# Optional: enterprise license PEM (leave empty in xtm_one mode)
+XTM_ONE_ENTERPRISE_LICENSE=
+XTM_ONE_LOG_LEVEL=info
+XTM_ONE_LOG_FORMAT=json

--- a/.env.sample
+++ b/.env.sample
@@ -63,8 +63,9 @@ XTM_ONE_PORT=4000
 XTM_ONE_EXTERNAL_SCHEME=http
 # Image tag for filigran/xtm-one and filigran/xtm-one-worker (e.g. rolling, 1.x.y)
 XTM_ONE_VERSION=rolling
-XTM_ONE_ADMIN_EMAIL=admin@filigran.io
-XTM_ONE_ADMIN_PASSWORD=ChangeMe
+# Must match OPENCTI_ADMIN_EMAIL so XTM One's JWT is accepted by OpenCTI.
+XTM_ONE_ADMIN_EMAIL=admin@opencti.io
+XTM_ONE_ADMIN_PASSWORD=changeme
 # Long random string (e.g. `openssl rand -hex 32`). Used to sign sessions/tokens.
 XTM_ONE_SECRET_KEY=ChangeMeWithGeneratedRandomString
 # Credentials for the dedicated pgsql-copilot Postgres instance.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,7 +140,9 @@ services:
     environment:
       - NODE_OPTIONS=--max-old-space-size=8096
       - APP__PORT=8080
-      - APP__BASE_URL=${OPENCTI_EXTERNAL_SCHEME}://${OPENCTI_HOST}:${OPENCTI_PORT}
+      # APP__BASE_URL is used as the JWT ``aud`` validation target.  It MUST
+      # match what XTM One puts in the JWT audience claim (the internal URL).
+      - APP__BASE_URL=http://opencti:8080
       - APP__ADMIN__EMAIL=${OPENCTI_ADMIN_EMAIL}
       - APP__ADMIN__PASSWORD=${OPENCTI_ADMIN_PASSWORD}
       - APP__ADMIN__TOKEN=${OPENCTI_ADMIN_TOKEN}
@@ -355,7 +357,10 @@ services:
     environment:
       - PLATFORM_MODE=xtm_one
       - PLATFORM_REGISTRATION_TOKEN=${PLATFORM_REGISTRATION_TOKEN}
-      - BASE_URL=${XTM_ONE_EXTERNAL_SCHEME}://${XTM_ONE_HOST}:${XTM_ONE_PORT}
+      # BASE_URL is used as the JWT ``iss`` claim AND as the JWKS host that
+      # peer platforms (OpenCTI) fetch keys from.  It MUST be the internal
+      # Docker hostname so peers can verify tokens.
+      - BASE_URL=http://xtm-one:4000
       - FRONTEND_URL=${XTM_ONE_EXTERNAL_SCHEME}://${XTM_ONE_HOST}:${XTM_ONE_PORT}
       - ADMIN_EMAIL=${XTM_ONE_ADMIN_EMAIL}
       - ADMIN_PASSWORD=${XTM_ONE_ADMIN_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,21 @@ services:
       interval: 30s
       timeout: 30s
       retries: 3
+  pgsql-copilot:
+    # Dedicated pgvector-enabled instance for XTM One.
+    image: pgvector/pgvector:pg17
+    environment:
+      POSTGRES_USER: ${XTM_ONE_POSTGRES_USER}
+      POSTGRES_PASSWORD: ${XTM_ONE_POSTGRES_PASSWORD}
+      POSTGRES_DB: copilot
+    volumes:
+      - pgsqlcopilotdata:/var/lib/postgresql/data
+    restart: always
+    healthcheck:
+      test: [ "CMD", "pg_isready", "-U", "${XTM_ONE_POSTGRES_USER}", "-d", "copilot" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   ###########################
   # COMMON                  #
@@ -149,6 +164,9 @@ services:
       - SMTP__PORT=25
       - PROVIDERS__LOCAL__STRATEGY=LocalStrategy
       - APP__HEALTH_ACCESS_KEY=${OPENCTI_HEALTHCHECK_ACCESS_KEY}
+      # XTM One
+      - XTM__XTM_ONE_URL=http://xtm-one:4000
+      - XTM__XTM_ONE_TOKEN=${PLATFORM_REGISTRATION_TOKEN}
     ports:
       - "${OPENCTI_PORT}:8080"
     depends_on:
@@ -328,9 +346,79 @@ services:
       opencti:
         condition: service_healthy      
 
+  ###########################
+  # XTM ONE                 #
+  ###########################
+
+  xtm-one:
+    image: filigran/xtm-one:${XTM_ONE_VERSION:-rolling}
+    environment:
+      - PLATFORM_MODE=xtm_one
+      - PLATFORM_REGISTRATION_TOKEN=${PLATFORM_REGISTRATION_TOKEN}
+      - BASE_URL=${XTM_ONE_EXTERNAL_SCHEME}://${XTM_ONE_HOST}:${XTM_ONE_PORT}
+      - FRONTEND_URL=${XTM_ONE_EXTERNAL_SCHEME}://${XTM_ONE_HOST}:${XTM_ONE_PORT}
+      - ADMIN_EMAIL=${XTM_ONE_ADMIN_EMAIL}
+      - ADMIN_PASSWORD=${XTM_ONE_ADMIN_PASSWORD}
+      - SECRET_KEY=${XTM_ONE_SECRET_KEY}
+      - DATABASE_URL=postgresql+asyncpg://${XTM_ONE_POSTGRES_USER}:${XTM_ONE_POSTGRES_PASSWORD}@pgsql-copilot:5432/copilot
+      - REDIS_URL=redis://redis:6379
+      - S3_ENDPOINT=minio:9000
+      - S3_ACCESS_KEY=${MINIO_ROOT_USER}
+      - S3_SECRET_KEY=${MINIO_ROOT_PASSWORD}
+      - S3_BUCKET=${XTM_ONE_S3_BUCKET:-copilot-files}
+      - S3_USE_SSL=false
+      - LOG_LEVEL=${XTM_ONE_LOG_LEVEL:-info}
+      - LOG_FORMAT=${XTM_ONE_LOG_FORMAT:-json}
+      - ENTERPRISE_LICENSE=${XTM_ONE_ENTERPRISE_LICENSE:-}
+      # OpenCTI federation
+      - OPENCTI_ENABLE=true
+      - OPENCTI_URL=${OPENCTI_EXTERNAL_SCHEME}://${OPENCTI_HOST}:${OPENCTI_PORT}
+      - OPENCTI_API_URL=http://opencti:8080
+      - OPENCTI_TOKEN=${OPENCTI_ADMIN_TOKEN}
+    ports:
+      - "${XTM_ONE_PORT}:4000"
+    depends_on:
+      pgsql-copilot:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:4000/api/health')\""]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
+  xtm-one-worker:
+    image: filigran/xtm-one-worker:${XTM_ONE_VERSION:-rolling}
+    environment:
+      - PLATFORM_MODE=xtm_one
+      - PLATFORM_REGISTRATION_TOKEN=${PLATFORM_REGISTRATION_TOKEN}
+      - ADMIN_EMAIL=${XTM_ONE_ADMIN_EMAIL}
+      - ADMIN_PASSWORD=${XTM_ONE_ADMIN_PASSWORD}
+      - SECRET_KEY=${XTM_ONE_SECRET_KEY}
+      - DATABASE_URL=postgresql+asyncpg://${XTM_ONE_POSTGRES_USER}:${XTM_ONE_POSTGRES_PASSWORD}@pgsql-copilot:5432/copilot
+      - REDIS_URL=redis://redis:6379
+      - S3_ENDPOINT=minio:9000
+      - S3_ACCESS_KEY=${MINIO_ROOT_USER}
+      - S3_SECRET_KEY=${MINIO_ROOT_PASSWORD}
+      - S3_BUCKET=${XTM_ONE_S3_BUCKET:-copilot-files}
+      - S3_USE_SSL=false
+      - LOG_LEVEL=${XTM_ONE_LOG_LEVEL:-info}
+      - LOG_FORMAT=${XTM_ONE_LOG_FORMAT:-json}
+      - ENTERPRISE_LICENSE=${XTM_ONE_ENTERPRISE_LICENSE:-}
+    depends_on:
+      xtm-one:
+        condition: service_healthy
+    restart: always
+
 volumes:
   esdata:
   s3data:
   redisdata:
   amqpdata:
   rsakeys:
+  pgsqlcopilotdata:


### PR DESCRIPTION
## Objective

Adds XTM One alongside OpenCTI in the default Docker stack so `docker compose up -d` brings the full XTM One + OpenCTI experience by default.

Refs XTM-One-Platform/xtm-one#1011. Companion PRs:
- FiligranHQ/xtm-docker#15 (full unified stack)
- OpenAEV-Platform/docker (to follow)

## Changes

**New services**
- `pgsql-copilot` (`pgvector/pgvector:pg17`) — Postgres+pgvector instance dedicated to XTM One, with its own credentials.
- `xtm-one` — exposes the XTM One UI/API on `${XTM_ONE_PORT}` (default `4000`), reuses the existing `redis` and `minio`.
- `xtm-one-worker` — async worker, depends on `xtm-one` being healthy.

**Inter-platform wiring**
- New `PLATFORM_REGISTRATION_TOKEN` shared secret.
- `opencti` service now receives `XTM__XTM_ONE_URL` / `XTM__XTM_ONE_TOKEN`.
- `xtm-one` service receives `OPENCTI_*` federation env vars (URL, internal API URL, admin token).

**Documentation**
- `.env.sample` gets a new `XTM ONE` block documenting admin credentials, image tag, dedicated Postgres credentials, S3 bucket, optional license, and the shared `PLATFORM_REGISTRATION_TOKEN`.

**Scope**
- Only `docker-compose.yml` is touched. `docker-compose.dev.yml` and `docker-compose.opensearch.yml` are intentionally left alone for now and will be handled in follow-ups if needed.

## Verification

The same configuration has been validated end-to-end inside the unified [xtm-docker](https://github.com/FiligranHQ/xtm-docker) stack (companion PR FiligranHQ/xtm-docker#15): all services reach `healthy`, OpenCTI and XTM One register successfully via `PLATFORM_REGISTRATION_TOKEN`, and cross-platform features work as expected.

## Notes

- `OPENCTI_ENCRYPTION_KEY` must be a 32-byte base64 string (`openssl rand -base64 32`), not a UUID. The placeholder in `.env.sample` already hints at this; happy to add a more explicit comment if reviewers want.
- The xtm-one yaml here is a convenience copy of what lives in `FiligranHQ/xtm-docker` (canonical source). Keeping it minimal so future syncs stay easy.