### PR TITLE
feat: bundle XTM One in the default stack

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -49,3 +49,30 @@ CONNECTOR_ANALYSIS_ID=4dffd77c-ec11-4abe-bca7-fd997f79fa36
 
 CONNECTOR_OPENCTI_ID=dd010812-9027-4726-bf7b-4936979955ae
 CONNECTOR_MITRE_ID=8307ea1e-9356-408c-a510-2d7f8b28a0e2
+
+###########################
+# XTM ONE                 #
+###########################
+
+# Shared secret used by OpenCTI and XTM One to authenticate registration.
+# Both platforms MUST use the same value.
+PLATFORM_REGISTRATION_TOKEN=xtm-default-registration-token
+
+XTM_ONE_HOST=localhost
+XTM_ONE_PORT=4000
+XTM_ONE_EXTERNAL_SCHEME=http
+# Image tag for filigran/xtm-one and filigran/xtm-one-worker (e.g. rolling, 1.x.y)
+XTM_ONE_VERSION=rolling
+XTM_ONE_ADMIN_EMAIL=admin@filigran.io
+XTM_ONE_ADMIN_PASSWORD=ChangeMe
+# Long random string (e.g. `openssl rand -hex 32`). Used to sign sessions/tokens.
+XTM_ONE_SECRET_KEY=ChangeMeWithGeneratedRandomString
+# Credentials for the dedicated pgsql-copilot Postgres instance.
+XTM_ONE_POSTGRES_USER=copilot
+XTM_ONE_POSTGRES_PASSWORD=ChangeMe
+# Optional: bucket name in MinIO (auto-created on first boot)
+XTM_ONE_S3_BUCKET=copilot-files
+# Optional: enterprise license PEM (leave empty in xtm_one mode)
+XTM_ONE_ENTERPRISE_LICENSE=
+XTM_ONE_LOG_LEVEL=info
+XTM_ONE_LOG_FORMAT=json

--- a/.env.sample
+++ b/.env.sample
@@ -63,8 +63,9 @@ XTM_ONE_PORT=4000
 XTM_ONE_EXTERNAL_SCHEME=http
 # Image tag for filigran/xtm-one and filigran/xtm-one-worker (e.g. rolling, 1.x.y)
 XTM_ONE_VERSION=rolling
-XTM_ONE_ADMIN_EMAIL=admin@filigran.io
-XTM_ONE_ADMIN_PASSWORD=ChangeMe
+# Must match OPENCTI_ADMIN_EMAIL so XTM One's JWT is accepted by OpenCTI.
+XTM_ONE_ADMIN_EMAIL=admin@opencti.io
+XTM_ONE_ADMIN_PASSWORD=changeme
 # Long random string (e.g. `openssl rand -hex 32`). Used to sign sessions/tokens.
 XTM_ONE_SECRET_KEY=ChangeMeWithGeneratedRandomString
 # Credentials for the dedicated pgsql-copilot Postgres instance.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,7 +140,9 @@ services:
     environment:
       - NODE_OPTIONS=--max-old-space-size=8096
       - APP__PORT=8080
-      - APP__BASE_URL=${OPENCTI_EXTERNAL_SCHEME}://${OPENCTI_HOST}:${OPENCTI_PORT}
+      # APP__BASE_URL is used as the JWT ``aud`` validation target.  It MUST
+      # match what XTM One puts in the JWT audience claim (the internal URL).
+      - APP__BASE_URL=http://opencti:8080
       - APP__ADMIN__EMAIL=${OPENCTI_ADMIN_EMAIL}
       - APP__ADMIN__PASSWORD=${OPENCTI_ADMIN_PASSWORD}
       - APP__ADMIN__TOKEN=${OPENCTI_ADMIN_TOKEN}
@@ -355,7 +357,10 @@ services:
     environment:
       - PLATFORM_MODE=xtm_one
       - PLATFORM_REGISTRATION_TOKEN=${PLATFORM_REGISTRATION_TOKEN}
-      - BASE_URL=${XTM_ONE_EXTERNAL_SCHEME}://${XTM_ONE_HOST}:${XTM_ONE_PORT}
+      # BASE_URL is used as the JWT ``iss`` claim AND as the JWKS host that
+      # peer platforms (OpenCTI) fetch keys from.  It MUST be the internal
+      # Docker hostname so peers can verify tokens.
+      - BASE_URL=http://xtm-one:4000
       - FRONTEND_URL=${XTM_ONE_EXTERNAL_SCHEME}://${XTM_ONE_HOST}:${XTM_ONE_PORT}
       - ADMIN_EMAIL=${XTM_ONE_ADMIN_EMAIL}
       - ADMIN_PASSWORD=${XTM_ONE_ADMIN_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,21 @@ services:
       interval: 30s
       timeout: 30s
       retries: 3
+  pgsql-copilot:
+    # Dedicated pgvector-enabled instance for XTM One.
+    image: pgvector/pgvector:pg17
+    environment:
+      POSTGRES_USER: ${XTM_ONE_POSTGRES_USER}
+      POSTGRES_PASSWORD: ${XTM_ONE_POSTGRES_PASSWORD}
+      POSTGRES_DB: copilot
+    volumes:
+      - pgsqlcopilotdata:/var/lib/postgresql/data
+    restart: always
+    healthcheck:
+      test: [ "CMD", "pg_isready", "-U", "${XTM_ONE_POSTGRES_USER}", "-d", "copilot" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   ###########################
   # COMMON                  #
@@ -149,6 +164,9 @@ services:
       - SMTP__PORT=25
       - PROVIDERS__LOCAL__STRATEGY=LocalStrategy
       - APP__HEALTH_ACCESS_KEY=${OPENCTI_HEALTHCHECK_ACCESS_KEY}
+      # XTM One
+      - XTM__XTM_ONE_URL=http://xtm-one:4000
+      - XTM__XTM_ONE_TOKEN=${PLATFORM_REGISTRATION_TOKEN}
     ports:
       - "${OPENCTI_PORT}:8080"
     depends_on:
@@ -328,9 +346,79 @@ services:
       opencti:
         condition: service_healthy      
 
+  ###########################
+  # XTM ONE                 #
+  ###########################
+
+  xtm-one:
+    image: filigran/xtm-one:${XTM_ONE_VERSION:-rolling}
+    environment:
+      - PLATFORM_MODE=xtm_one
+      - PLATFORM_REGISTRATION_TOKEN=${PLATFORM_REGISTRATION_TOKEN}
+      - BASE_URL=${XTM_ONE_EXTERNAL_SCHEME}://${XTM_ONE_HOST}:${XTM_ONE_PORT}
+      - FRONTEND_URL=${XTM_ONE_EXTERNAL_SCHEME}://${XTM_ONE_HOST}:${XTM_ONE_PORT}
+      - ADMIN_EMAIL=${XTM_ONE_ADMIN_EMAIL}
+      - ADMIN_PASSWORD=${XTM_ONE_ADMIN_PASSWORD}
+      - SECRET_KEY=${XTM_ONE_SECRET_KEY}
+      - DATABASE_URL=postgresql+asyncpg://${XTM_ONE_POSTGRES_USER}:${XTM_ONE_POSTGRES_PASSWORD}@pgsql-copilot:5432/copilot
+      - REDIS_URL=redis://redis:6379
+      - S3_ENDPOINT=minio:9000
+      - S3_ACCESS_KEY=${MINIO_ROOT_USER}
+      - S3_SECRET_KEY=${MINIO_ROOT_PASSWORD}
+      - S3_BUCKET=${XTM_ONE_S3_BUCKET:-copilot-files}
+      - S3_USE_SSL=false
+      - LOG_LEVEL=${XTM_ONE_LOG_LEVEL:-info}
+      - LOG_FORMAT=${XTM_ONE_LOG_FORMAT:-json}
+      - ENTERPRISE_LICENSE=${XTM_ONE_ENTERPRISE_LICENSE:-}
+      # OpenCTI federation
+      - OPENCTI_ENABLE=true
+      - OPENCTI_URL=${OPENCTI_EXTERNAL_SCHEME}://${OPENCTI_HOST}:${OPENCTI_PORT}
+      - OPENCTI_API_URL=http://opencti:8080
+      - OPENCTI_TOKEN=${OPENCTI_ADMIN_TOKEN}
+    ports:
+      - "${XTM_ONE_PORT}:4000"
+    depends_on:
+      pgsql-copilot:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:4000/api/health')\""]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
+  xtm-one-worker:
+    image: filigran/xtm-one-worker:${XTM_ONE_VERSION:-rolling}
+    environment:
+      - PLATFORM_MODE=xtm_one
+      - PLATFORM_REGISTRATION_TOKEN=${PLATFORM_REGISTRATION_TOKEN}
+      - ADMIN_EMAIL=${XTM_ONE_ADMIN_EMAIL}
+      - ADMIN_PASSWORD=${XTM_ONE_ADMIN_PASSWORD}
+      - SECRET_KEY=${XTM_ONE_SECRET_KEY}
+      - DATABASE_URL=postgresql+asyncpg://${XTM_ONE_POSTGRES_USER}:${XTM_ONE_POSTGRES_PASSWORD}@pgsql-copilot:5432/copilot
+      - REDIS_URL=redis://redis:6379
+      - S3_ENDPOINT=minio:9000
+      - S3_ACCESS_KEY=${MINIO_ROOT_USER}
+      - S3_SECRET_KEY=${MINIO_ROOT_PASSWORD}
+      - S3_BUCKET=${XTM_ONE_S3_BUCKET:-copilot-files}
+      - S3_USE_SSL=false
+      - LOG_LEVEL=${XTM_ONE_LOG_LEVEL:-info}
+      - LOG_FORMAT=${XTM_ONE_LOG_FORMAT:-json}
+      - ENTERPRISE_LICENSE=${XTM_ONE_ENTERPRISE_LICENSE:-}
+    depends_on:
+      xtm-one:
+        condition: service_healthy
+    restart: always
+
 volumes:
   esdata:
   s3data:
   redisdata:
   amqpdata:
   rsakeys:
+  pgsqlcopilotdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -353,6 +353,9 @@ services:
   ###########################
 
   xtm-one:
+    build:
+      context: ../xtm-one
+      dockerfile: Dockerfile
     image: filigran/xtm-one:${XTM_ONE_VERSION:-rolling}
     environment:
       - PLATFORM_MODE=xtm_one
@@ -398,6 +401,9 @@ services:
       start_period: 60s
 
   xtm-one-worker:
+    build:
+      context: ../xtm-one
+      dockerfile: Dockerfile.worker
     image: filigran/xtm-one-worker:${XTM_ONE_VERSION:-rolling}
     environment:
       - PLATFORM_MODE=xtm_one


### PR DESCRIPTION
## ✅ Tested: OpenCTI + XTM One Docker Setup

Clean `docker compose up -d` from scratch — verified end-to-end.

### Steps to reproduce

```bash
# 1. Clone repos side-by-side
git clone git@github.com:OpenCTI-Platform/docker.git opencti-docker
git clone git@github.com:XTM-One-Platform/xtm-one.git xtm-one
cd opencti-docker
git checkout feat/xtm-one-default

# 2. Create .env from sample (only 3 values MUST be changed)
cp .env.sample .env
sed -i "s/OPENCTI_ADMIN_TOKEN=ChangeMe_UUIDv4/OPENCTI_ADMIN_TOKEN=$(uuidgen)/" .env
sed -i "s|OPENCTI_ENCRYPTION_KEY=ChangeMeWithGeneratedBase64Key|OPENCTI_ENCRYPTION_KEY=$(openssl rand -base64 32)|" .env
sed -i "s/XTM_ONE_SECRET_KEY=ChangeMeWithGeneratedRandomString/XTM_ONE_SECRET_KEY=$(openssl rand -hex 32)/" .env

# 3. Build and start
docker compose up -d --build

# 4. Wait (~1-2 min) then verify
docker compose ps  # all services healthy
```

> **Note:** The compose file has `build: context: ../xtm-one` directives for `xtm-one` and `xtm-one-worker` services. This requires the `xtm-one` repo cloned adjacent to this repo. Alternatively, remove the `build:` blocks and pull a pre-built image.

### Credentials
| Service | URL | Email | Password |
|---------|-----|-------|----------|
| OpenCTI | http://localhost:8080 | `admin@opencti.io` | `changeme` |
| XTM One | http://localhost:4000 | `admin@opencti.io` | `changeme` |

### What was verified
- All 23 services start healthy (infra, OpenCTI, connectors, workers, XTM One, XTM Composer)
- OpenCTI auto-registers with XTM One (status=active, heartbeat flowing)
- XTM One integration shows `status=connected`, `base_url=http://opencti:8080`
- JWT auth from XTM One → OpenCTI GraphQL works (`iss=http://xtm-one:4000`, `aud=http://opencti:8080`)
- JWKS endpoint reachable cross-container

### Key fixes in this commit
1. **`APP__BASE_URL=http://opencti:8080`** — JWT audience validation must match the internal hostname
2. **`BASE_URL=http://xtm-one:4000`** — JWT issuer + JWKS fetch must use internal hostname
3. **`XTM_ONE_ADMIN_EMAIL=admin@opencti.io`** — must match OpenCTI admin so JWT email resolves
4. **Build directives** — `build: context: ../xtm-one` for local builds without registry access

### Dependency
Requires [XTM-One-Platform/xtm-one#1070](https://github.com/XTM-One-Platform/xtm-one/pull/1070) (`fix/platform-registration-api-url-override`) — adds `OPENCTI_API_URL` env var support so the registration stores the internal Docker URL in the integration config instead of the platform-reported external URL.
