### PR TITLE
[docker] Group pgsql-xtm-one with dependencies and document XTM One

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@
 
 You can find the detailed documentation about the Docker installation in the [OpenCTI documentation space](https://docs.opencti.io/latest/deployment/installation/#using-docker).
 
+## XTM One
+
+This stack bundles [XTM One](https://filigran.io), Filigran's AI-powered assistant, alongside OpenCTI. The following services are started by default:
+
+| Service | Description |
+|---------|-------------|
+| `xtm-one` | XTM One platform (web UI + API, exposed on `XTM_ONE_PORT`) |
+| `xtm-one-worker` | XTM One background worker |
+| `pgsql-xtm-one` | Dedicated PostgreSQL + `pgvector` instance for XTM One |
+
+XTM One reuses the shared `redis` and `minio` services and connects to OpenCTI internally via `OPENCTI_API_URL`. OpenCTI registers itself with XTM One using `PLATFORM_REGISTRATION_TOKEN` — this shared secret **must be identical** across every platform connected to the same XTM One instance.
+
+All XTM One configuration (admin credentials, dedicated Postgres credentials, S3 bucket, license, log settings) lives in the `XTM ONE` section of [.env.sample](.env.sample). Once the stack is healthy, XTM One is available on `http://localhost:${XTM_ONE_PORT}` (default `8090`).
+
 ## Community
 
 ### Status & bugs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,21 @@ services:
       interval: 5s
       timeout: 3s
       retries: 50
+  pgsql-xtm-one:
+    # Dedicated pgvector-enabled instance for XTM One.
+    image: pgvector/pgvector:pg17
+    environment:
+      POSTGRES_USER: ${XTM_ONE_POSTGRES_USER}
+      POSTGRES_PASSWORD: ${XTM_ONE_POSTGRES_PASSWORD}
+      POSTGRES_DB: xtm_one
+    volumes:
+      - pgsqlxtmonedata:/var/lib/postgresql/data
+    restart: always
+    healthcheck:
+      test: [ "CMD", "pg_isready", "-U", "${XTM_ONE_POSTGRES_USER}", "-d", "xtm_one" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
   minio:
     image: minio/minio:latest
     volumes:
@@ -334,22 +349,6 @@ services:
   ###########################
   # XTM ONE                 #
   ###########################
-
-  pgsql-xtm-one:
-    # Dedicated pgvector-enabled instance for XTM One.
-    image: pgvector/pgvector:pg17
-    environment:
-      POSTGRES_USER: ${XTM_ONE_POSTGRES_USER}
-      POSTGRES_PASSWORD: ${XTM_ONE_POSTGRES_PASSWORD}
-      POSTGRES_DB: xtm_one
-    volumes:
-      - pgsqlxtmonedata:/var/lib/postgresql/data
-    restart: always
-    healthcheck:
-      test: [ "CMD", "pg_isready", "-U", "${XTM_ONE_POSTGRES_USER}", "-d", "xtm_one" ]
-      interval: 10s
-      timeout: 5s
-      retries: 5
 
   xtm-one:
     image: xtmone/platform:latest


### PR DESCRIPTION
## Summary

Aligns the bundled XTM One configuration with the other XTM docker stacks (`FiligranHQ/xtm-docker`, `OpenAEV-Platform/docker`) for cross-repo consistency.

- Move the dedicated `pgsql-xtm-one` (PostgreSQL + pgvector) service from the `# XTM ONE` block into the `# DEPENDENCIES` section, so it is grouped with the other datastores like in `xtm-docker`. No functional change — `xtm-one` still `depends_on` it.
- Document the bundled XTM One services (`xtm-one`, `xtm-one-worker`, `pgsql-xtm-one`) in the README, which previously did not mention XTM One at all.

## Test plan
- [x] `docker compose --env-file .env.sample -f docker-compose.yml config` validates with no errors
- [ ] Stack boots and XTM One reaches healthy state