### PR TITLE
chore: align issue templates across repositories (#586)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a bug report to help us improve
+about: Create a bug report to help us improve OpenCTI
 title: 'fix: '
 labels: needs triage, bug
 assignees: ''
@@ -15,7 +15,7 @@ type: bug
 ## Environment
 
 1. OS: { e.g. macOS 14, Windows 11, Ubuntu 22.04, etc. }
-2. Version: { e.g. 1.0.0 }
+2. Version: { e.g. 1.2.3 }
 3. Other environment details:
 
 ## Reproducible steps

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/OpenCTI-Platform/docker/security/policy
+    about: Please review our security policy and report vulnerabilities privately and responsibly.
+  - name: Filigran community Slack
+    url: https://community.filigran.io
+    about: Ask questions and chat with the Filigran community.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest a new feature or capability
+about: Suggest a new feature or capability for OpenCTI
 title: 'feat: '
 labels: needs triage, feature
 assignees: ''
@@ -23,3 +23,7 @@ type: feature
 ## Additional information
 
 <!-- Any additional information, including logs or screenshots if you have any. -->
+
+## If the feature request is approved, would you be willing to submit a PR?
+
+Yes / No (help can be provided if you need assistance submitting a PR)

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: Question
-about: Ask a question about the project
+about: Ask a question about OpenCTI
 title: ''
 labels: needs triage, question
 assignees: ''
@@ -16,6 +16,12 @@ assignees: ''
 ## Description
 
 <!-- Please provide a clear and concise description of your question. -->
+
+## Environment
+
+1. OS: { e.g. macOS 14, Windows 11, Ubuntu 22.04, etc. }
+2. Version: { e.g. 1.2.3 }
+3. Other environment details:
 
 ## Additional information
 


### PR DESCRIPTION
## Summary

Aligns the issue templates across all Filigran repositories (identical bug / feature / question + a security vulnerability link), adds a documentation request template where the repo ships docs, and keeps client-python templates where applicable.

Closes #586