### PR TITLE
chore: audit & align issue templates (#588)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,1 @@
 blank_issues_enabled: true
-contact_links:
-  - name: Report a security vulnerability
-    url: https://github.com/OpenCTI-Platform/docker/security/policy
-    about: Please review our security policy and report vulnerabilities privately and responsibly.
-  - name: Filigran community Slack
-    url: https://community.filigran.io
-    about: Ask questions and chat with the Filigran community.


### PR DESCRIPTION
Closes #588

Audits and aligns the GitHub issue templates with the canonical Filigran standard.

## Changes
- `config.yml` set to the public standard (`blank_issues_enabled: true` only).
- Removed the duplicate security `contact_link` — native private vulnerability reporting is enabled on this repository.
- Removed the Filigran community Slack `contact_link`.
- Verified `bug_report.md`, `feature_request.md` and `question.md` names, descriptions, titles, labels and types are consistent with the standard (no duplicates).

No documentation or pycti templates apply to this repository.